### PR TITLE
Fix playQueue when switching music sources

### DIFF
--- a/src/Sonos-ESP32-master/src/SonosUPnP.cpp
+++ b/src/Sonos-ESP32-master/src/SonosUPnP.cpp
@@ -259,9 +259,11 @@ void SonosUPnP::cueQueue(IPAddress speakerIP, const char *speakerID)
 
 void SonosUPnP::playQueue(IPAddress speakerIP, const char *speakerID)
 {
-  char address[30];
-  sprintf_P(address, p_SourceRinconTemplate, speakerID, UPNP_PORT, "#0");
-  setAVTransportURI(speakerIP, SONOS_SOURCE_QUEUE_SCHEME, address);
+  char address[42];
+  sprintf(address, "%s%s#0", SONOS_SOURCE_QUEUE_SCHEME, speakerID);
+  upnpSet(
+    speakerIP, UPNP_AV_TRANSPORT, p_SetAVTransportURI,
+    "CurrentURIMetaData", "", "", "<CurrentURI>", "</CurrentURI>", address);
   seekTrack(speakerIP, 1);
   play(speakerIP);
 }


### PR DESCRIPTION
Copied from https://docs.python-soco.com/en/latest/_modules/soco/core.html#SoCo.add_uri_to_queue

The original code was not far from this. 
Taken inspiration from the `seekTrack` function, which showed that you can pass extra parameters as XML to the `extraStart_P` arguments. In this we send the `CurrentURI` as the extra parameter, and use the main field to set the metadata to the empty string.

Tested, and works when switching to queued items from other sources, such as Sonos Radio.

Note: the speaker ID should be the same as what `soco.uid` outputs, something like `RINCON_5CAAFDE4DE1801400`